### PR TITLE
feat: Remove uneeded trait behind actor and commit

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,39 +1,30 @@
 use chrono::{DateTime, Utc};
 use git2::Signature;
 
-#[cfg_attr(test, mockall::automock)]
-pub trait MinedActor {
-    /// Return the actors name if it exists
-    fn name(&self) -> Option<String>;
-
-    /// Return the actors email if it exists
-    fn email(&self) -> Option<String>;
-
-    /// Return the timestamp of the actors action (authorship/commit)
-    fn timestamp(&self) -> Option<DateTime<Utc>>;
-}
-
 /// A git actor who exists for the inspected repository
-pub struct Actor<'a>(Signature<'a>);
+pub struct Actor<'a> {
+    inner: Signature<'a>,
+}
 
 impl<'a> Actor<'a> {
     /// Instantiate a new Actor from their signature
-    pub fn new(s: Signature<'a>) -> Self {
-        Self(s)
-    }
-}
-
-impl<'a> MinedActor for Actor<'a> {
-    fn name(&self) -> Option<String> {
-        self.0.name().map(|s| s.to_string())
+    pub fn new(signature: Signature<'a>) -> Self {
+        Self { inner: signature }
     }
 
-    fn email(&self) -> Option<String> {
-        self.0.email().map(|s| s.to_string())
+    /// Return the actors name if it exists
+    pub fn name(&self) -> Option<String> {
+        self.inner.name().map(|s| s.to_string())
     }
 
-    fn timestamp(&self) -> Option<DateTime<Utc>> {
-        DateTime::from_timestamp_secs(self.0.when().seconds())
+    /// Return the actors email if it exists
+    pub fn email(&self) -> Option<String> {
+        self.inner.email().map(|s| s.to_string())
+    }
+
+    /// Return the timestamp of actor action if it exists
+    pub fn timestamp(&self) -> Option<DateTime<Utc>> {
+        DateTime::from_timestamp_secs(self.inner.when().seconds())
     }
 }
 
@@ -41,35 +32,19 @@ impl<'a> MinedActor for Actor<'a> {
 mod tests {
     use super::*;
 
-    fn actor_factory() -> MockMinedActor {
-        MockMinedActor::new()
-    }
-
     #[test]
-    fn test_name() {
-        let mut actor = actor_factory();
-        actor.expect_name().return_const("john".to_string());
+    fn test_actor() {
+        let sig = Signature::new(
+            "test",
+            "test@example.com",
+            &git2::Time::new(1_600_000_000, 0),
+        )
+        .unwrap();
 
-        assert_eq!(actor.name(), Some("john".to_string()))
-    }
+        let actor = Actor::new(sig);
 
-    #[test]
-    fn test_email() {
-        let mut actor = actor_factory();
-        actor
-            .expect_email()
-            .return_const("john@example.com".to_string());
-
-        assert_eq!(actor.email(), Some("john@example.com".to_string()))
-    }
-
-    #[test]
-    fn test_timestamp() {
-        let time = Utc::now();
-
-        let mut actor = actor_factory();
-        actor.expect_timestamp().return_const(time);
-
-        assert_eq!(actor.timestamp(), Some(time))
+        assert_eq!(actor.name(), Some("test".to_string()));
+        assert_eq!(actor.email(), Some("test@example.com".to_string()));
+        assert_eq!(actor.timestamp().unwrap().timestamp(), 1_600_000_000);
     }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,196 +1,47 @@
-use git2::{Oid, Repository};
-
-use crate::actor::{Actor, MinedActor};
-
-// Can't use mockall::automock because of lifetimes :(
-pub trait MinedCommit<'a> {
-    type Actor: MinedActor + 'a;
-
-    /// Return the commit hash (AKA Oid)
-    fn hash(&self) -> String;
-
-    /// Return the commit message if it exists
-    fn msg(&self) -> Option<String>;
-
-    /// Return the commit author
-    fn author(&'a self) -> Self::Actor;
-
-    /// Return the commit committer
-    fn committer(&'a self) -> Self::Actor;
-
-    /// Return the commit parent hashes if they exits
-    fn parents(&self) -> Option<Vec<String>>;
-
-    /// Return whether or not the commit is a merge commit
-    ///
-    /// A merge commit is defined as a commit with more than one parent
-    fn is_merge(&self) -> bool;
-}
+use crate::actor::Actor;
 
 /// A singular git commit for the repository being inspected
-pub struct Commit<'a>(git2::Commit<'a>);
+pub struct Commit<'a> {
+    inner: git2::Commit<'a>,
+}
 
 impl<'a> Commit<'a> {
     /// Instantiate a new Commit object from a git2 commit
-    pub fn new(c: git2::Commit<'a>) -> Self {
-        Self(c)
+    pub fn new(inner: git2::Commit<'a>) -> Self {
+        Self { inner }
     }
 
-    /// Instantiate a new commit object from it's oid
-    pub fn from_oid(repo: &'a Repository, oid: Oid) -> Result<Self, git2::Error> {
-        Ok(Self(repo.find_commit(oid)?))
-    }
-}
-
-impl<'a> MinedCommit<'a> for Commit<'a> {
-    type Actor = Actor<'a>;
-
-    fn hash(&self) -> String {
-        self.0.id().to_string()
+    /// Return the commit hash
+    pub fn hash(&self) -> String {
+        self.inner.id().to_string()
     }
 
-    fn msg(&self) -> Option<String> {
-        self.0.message().map(|s| s.to_string())
+    /// Return the commit message if it exists
+    pub fn msg(&self) -> Option<String> {
+        self.inner.message().map(|s| s.to_string())
     }
 
-    fn author(&'a self) -> Self::Actor {
-        Actor::new(self.0.author())
+    /// Return the commit author
+    pub fn author(&'a self) -> Actor<'a> {
+        Actor::new(self.inner.author())
     }
 
-    fn committer(&'a self) -> Self::Actor {
-        Actor::new(self.0.committer())
+    /// Return the commit committer
+    pub fn committer(&'a self) -> Actor<'a> {
+        Actor::new(self.inner.committer())
     }
 
-    fn parents(&self) -> Option<Vec<String>> {
-        if self.0.parent_count() == 0 {
-            return None;
-        }
-
-        let mut parents: Vec<String> = Vec::new();
-        for id in self.0.parent_ids() {
-            parents.push(id.to_string());
-        }
-        Some(parents)
+    /// Retrun the hashes of all commit parents
+    pub fn parents(&self) -> Vec<String> {
+        self.inner.parent_ids().map(|id| id.to_string()).collect()
     }
 
-    fn is_merge(&self) -> bool {
-        self.0.parent_count() > 1
+    /// Return whether the commit is a merge commit
+    pub fn is_merge(&self) -> bool {
+        self.inner.parent_count() > 1
     }
 }
 
-// Manually mock objects necassary for testing the MinedCommit trait.
-#[cfg(test)]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct MockActor;
-
-#[cfg(test)]
-impl crate::actor::MinedActor for MockActor {
-    fn name(&self) -> Option<String> {
-        Some("test".to_string())
-    }
-    fn email(&self) -> Option<String> {
-        Some("test@example.com".to_string())
-    }
-    fn timestamp(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockall::mock;
-    use sha1::{Digest, Sha1};
-
-    mock! {
-        pub MinedCommit {}
-
-        impl MinedCommit<'_> for MinedCommit {
-            type Actor = MockActor;
-
-            fn hash(&self) -> String;
-            fn msg(&self) -> Option<String>;
-            fn author(&'_ self) -> MockActor;
-            fn committer(&'_ self) -> MockActor;
-            fn parents(&self) -> Option<Vec<String>>;
-            fn is_merge(&self) -> bool;
-        }
-    }
-
-    fn sha1_factory(v: &[u8]) -> String {
-        let mut hasher = Sha1::new();
-        hasher.update(v);
-
-        format!("{:x}", hasher.finalize())
-    }
-
-    fn commit_factory() -> MockMinedCommit {
-        MockMinedCommit::new()
-    }
-
-    #[test]
-    fn test_hash() {
-        let hash = sha1_factory(b"Hello World");
-
-        let v = hash.clone();
-        let mut commit = commit_factory();
-        commit.expect_hash().return_once(move || v);
-
-        assert_eq!(commit.hash(), hash)
-    }
-
-    #[test]
-    fn test_msg() {
-        let msg = Some("Hello World".to_string());
-
-        let v = msg.clone();
-        let mut commit = commit_factory();
-        commit.expect_msg().return_once(move || v);
-
-        assert_eq!(commit.msg(), msg)
-    }
-
-    #[test]
-    fn test_author() {
-        let actor = MockActor;
-
-        let v = actor.clone();
-        let mut commit = commit_factory();
-        commit.expect_author().return_once(move || v);
-
-        assert_eq!(commit.author(), actor)
-    }
-
-    #[test]
-    fn test_committer() {
-        let actor = MockActor;
-
-        let v = actor.clone();
-        let mut commit = commit_factory();
-        commit.expect_committer().return_once(move || v);
-
-        assert_eq!(commit.committer(), actor)
-    }
-
-    #[test]
-    fn test_parents() {
-        let parents = Some(vec![
-            sha1_factory(b"Hello World"),
-            sha1_factory(b"Hello There"),
-        ]);
-
-        let v = parents.clone();
-        let mut commit = commit_factory();
-        commit.expect_parents().return_once(move || v);
-
-        assert_eq!(commit.parents(), parents)
-    }
-
-    #[test]
-    fn test_is_merge() {
-        let mut commit = commit_factory();
-        commit.expect_is_merge().return_once(|| true);
-
-        assert!(commit.is_merge())
-    }
-}
+//TODO: Test without using a repository to fetch a commit?
+// This is harder than it sounds. May require a redesign of commits to not be
+// tightly coupled with git2.

--- a/src/repository/iter.rs
+++ b/src/repository/iter.rs
@@ -1,6 +1,8 @@
 // Define any and all iterators relating to the repository class.
+use crate::Error;
 use crate::commit::Commit;
 
+//TODO: This should probably run on generics rather than git2::Commit
 /// Define state to keep track of during commit iteration
 pub struct CommitIterator<'iter> {
     repo: &'iter git2::Repository,
@@ -8,22 +10,26 @@ pub struct CommitIterator<'iter> {
 }
 
 impl<'iter> CommitIterator<'iter> {
-    pub fn new(repo: &'iter git2::Repository) -> Result<Self, git2::Error> {
-        let mut walker = repo.revwalk()?;
+    pub fn new(repo: &'iter git2::Repository) -> Result<Self, Error> {
+        let mut walker = repo.revwalk().map_err(Error::Git)?;
         //TODO: Allow pushing of any arbitrary commit
-        walker.push_head()?;
+        walker.push_head().map_err(Error::Git)?;
 
         Ok(Self { repo, walker })
     }
 }
 
 impl<'a> Iterator for CommitIterator<'a> {
-    type Item = Result<Commit<'a>, git2::Error>;
+    type Item = Result<Commit<'a>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.walker.next()? {
-            Ok(oid) => Some(Commit::from_oid(self.repo, oid)),
-            Err(e) => Some(Err(e)),
-        }
+        self.walker.next().map(|oid_result| {
+            oid_result.map_err(Error::Git).and_then(|oid| {
+                self.repo
+                    .find_commit(oid)
+                    .map(Commit::new)
+                    .map_err(Error::Git)
+            })
+        })
     }
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -43,9 +43,9 @@ impl Repository<Local> {
     }
 
     #[allow(dead_code)]
-    pub fn iter_commits<'repo>(
-        &'repo self,
-    ) -> Result<impl Iterator<Item = Result<Commit<'repo>, git2::Error>> + 'repo, git2::Error> {
+    pub fn iter_commits(
+        &'_ self,
+    ) -> Result<impl Iterator<Item = Result<Commit<'_>, Error>>, Error> {
         CommitIterator::new(&self.git_repo)
     }
 }

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -5,8 +5,6 @@ mod common;
 use common::make_repo;
 
 use stratum::{Local, Repository};
-//TODO: Should I bother with traits given the import overhead on the user?
-use stratum::{actor::MinedActor, commit::MinedCommit};
 
 #[test]
 fn init_repo_from_path() {
@@ -28,7 +26,7 @@ fn test_commit_traversal() {
         assert_eq!(commit.msg(), Some(common::EXPECTED_MSG.to_string()));
 
         assert!(!commit.is_merge());
-        assert_eq!(commit.parents(), None);
+        assert!(commit.parents().is_empty());
         // Check author equivalence
         assert_eq!(
             commit.author().name(),


### PR DESCRIPTION
Remove the traits which back the actor and commit as there should be no other impls for said traits. This also saves users from importing traits to use the lib.

This has come at the cost of not having any tests for the commit, but it is *somewhat* covered by the integration tests with a dummy repo