### PR TITLE
feat: Implement actor to be generic and depend on a trait to invert dependancies

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,30 +1,45 @@
 use chrono::{DateTime, Utc};
-use git2::Signature;
 
-/// A git actor who exists for the inspected repository
-pub struct Actor<'a> {
-    inner: Signature<'a>,
+use crate::interface::GitActor;
+
+impl GitActor for git2::Signature<'_> {
+    fn name(&self) -> Option<String> {
+        self.name().map(String::from)
+    }
+
+    fn email(&self) -> Option<String> {
+        self.email().map(String::from)
+    }
+
+    fn seconds(&self) -> i64 {
+        self.when().seconds()
+    }
 }
 
-impl<'a> Actor<'a> {
+/// A git actor who exists for the inspected repository
+pub struct Actor<S: GitActor> {
+    inner: S,
+}
+
+impl<S: GitActor> Actor<S> {
     /// Instantiate a new Actor from their signature
-    pub fn new(signature: Signature<'a>) -> Self {
+    pub fn new(signature: S) -> Self {
         Self { inner: signature }
     }
 
     /// Return the actors name if it exists
     pub fn name(&self) -> Option<String> {
-        self.inner.name().map(|s| s.to_string())
+        self.inner.name()
     }
 
     /// Return the actors email if it exists
     pub fn email(&self) -> Option<String> {
-        self.inner.email().map(|s| s.to_string())
+        self.inner.email()
     }
 
     /// Return the timestamp of actor action if it exists
     pub fn timestamp(&self) -> Option<DateTime<Utc>> {
-        DateTime::from_timestamp_secs(self.inner.when().seconds())
+        DateTime::from_timestamp_secs(self.inner.seconds())
     }
 }
 
@@ -34,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_actor() {
-        let sig = Signature::new(
+        let sig = git2::Signature::new(
             "test",
             "test@example.com",
             &git2::Time::new(1_600_000_000, 0),

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -21,13 +21,14 @@ impl<'a> Commit<'a> {
         self.inner.message().map(|s| s.to_string())
     }
 
+    //TODO: Inject dependancy into Commit to keep generic?
     /// Return the commit author
-    pub fn author(&'a self) -> Actor<'a> {
+    pub fn author(&self) -> Actor<git2::Signature<'_>> {
         Actor::new(self.inner.author())
     }
 
     /// Return the commit committer
-    pub fn committer(&'a self) -> Actor<'a> {
+    pub fn committer(&self) -> Actor<git2::Signature<'_>> {
         Actor::new(self.inner.committer())
     }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,41 @@
+#[cfg_attr(test, mockall::automock)]
+pub trait GitActor {
+    /// The name of the actor
+    fn name(&self) -> Option<String>;
+    /// The email of the actor
+    fn email(&self) -> Option<String>;
+    /// The number of seconds since epoch when the actors action occured
+    fn seconds(&self) -> i64;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn actor_factory() -> MockGitActor {
+        MockGitActor::new()
+    }
+
+    #[test]
+    fn test_name() {
+        let mut actor = actor_factory();
+        actor.expect_name().return_once(|| Some("test".to_string()));
+        assert_eq!(actor.name(), Some("test".to_string()));
+    }
+
+    #[test]
+    fn test_email() {
+        let mut actor = actor_factory();
+        actor
+            .expect_email()
+            .return_once(|| Some("test".to_string()));
+        assert_eq!(actor.email(), Some("test".to_string()));
+    }
+
+    #[test]
+    fn test_seconds() {
+        let mut actor = actor_factory();
+        actor.expect_seconds().return_once(|| 1_600_000_000);
+        assert_eq!(actor.seconds(), 1_600_000_000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 pub mod actor;
 pub mod commit;
+mod interface;
 pub mod repository;
 
 pub use actor::Actor;


### PR DESCRIPTION
Has the side effect that Actor no longer requires explicit lifetimes and all fn returns are implicitly owned