### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/segfault-merchant/git-stratum/compare/v0.2.0...v0.2.1) - 2026-04-28
+
+### Added
+
+- test new semantic release method
+
+### Fixed
+
+- update token name to match secrets
+
+### Other
+
+- to use release-plz quick start config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/segfault-merchant/git-stratum/compare/v0.2.0...v0.2.1) - 2026-04-28

### Added

- test new semantic release method

### Fixed

- update token name to match secrets

### Other

- to use release-plz quick start config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).