### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/segfault-merchant/git-stratum/compare/v0.2.1...v0.2.2) - 2026-05-01
+
+### Other
+
+- update README to match testing
+- *(test)* Unitise test repo generation to ensure readability
+
 ## [0.2.1](https://github.com/segfault-merchant/git-stratum/compare/v0.2.0...v0.2.1) - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/segfault-merchant/git-stratum/compare/v0.2.1...v0.2.2) - 2026-05-01

### Other

- update README to match testing
- *(test)* Unitise test repo generation to ensure readability
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).