### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/segfault-merchant/git-stratum/compare/v0.2.2...v0.2.3) - 2026-05-03
+
+### Added
+
+- Define test helper function to instantiate repo from git2::Repo
+- Test new modified file struct
+- define a commits modified files in terms of the delta and patches
+
+### Fixed
+
+- Ensure commit testing adheres to new test repo return
+- unit test repo generation should return git2::Repo to enable more explciit testing
+
+### Other
+
+- import git2 objects to simplify content
+- Prefer use of delta for delta-related methods as it's cheaper than patches
+- release v0.2.2
+- update README to match testing
+- *(test)* Unitise test repo generation to ensure readability
+
 ## [0.2.2](https://github.com/segfault-merchant/git-stratum/compare/v0.2.1...v0.2.2) - 2026-05-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/segfault-merchant/git-stratum/compare/v0.2.2...v0.2.3) - 2026-05-03

### Added

- Define test helper function to instantiate repo from git2::Repo
- Test new modified file struct
- define a commits modified files in terms of the delta and patches

### Fixed

- Ensure commit testing adheres to new test repo return
- unit test repo generation should return git2::Repo to enable more explciit testing

### Other

- import git2 objects to simplify content
- Prefer use of delta for delta-related methods as it's cheaper than patches
- release v0.2.2
- update README to match testing
- *(test)* Unitise test repo generation to ensure readability
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).