### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/segfault-merchant/git-stratum/compare/v0.2.4...v0.3.0) - 2026-05-06
+
+### Added
+
+- Define co_authors method
+- Implement FromStr on Actor
+- Add regex as dependency, include Regex error in stratum::Error
+
 ## [0.2.4](https://github.com/segfault-merchant/git-stratum/compare/v0.2.3...v0.2.4) - 2026-05-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.2.4 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `git-stratum` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Regex in /tmp/.tmpHMWTrM/git-stratum/src/lib.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/segfault-merchant/git-stratum/compare/v0.2.4...v0.3.0) - 2026-05-06

### Added

- Define co_authors method
- Implement FromStr on Actor
- Add regex as dependency, include Regex error in stratum::Error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).