### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/segfault-merchant/git-stratum/compare/v0.3.0...v0.3.1) - 2026-05-07
+
+### Added
+
+- Define methods to return all, local, and remote branches
+
+### Other
+
+- Test the new branch methods
+
 ## [0.3.0](https://github.com/segfault-merchant/git-stratum/compare/v0.2.4...v0.3.0) - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "git-url-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/segfault-merchant/git-stratum/compare/v0.3.0...v0.3.1) - 2026-05-07

### Added

- Define methods to return all, local, and remote branches

### Other

- Test the new branch methods
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).