### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/segfault-merchant/git-stratum/compare/v0.3.3...v0.3.4) - 2026-05-14
+
+### Added
+
+- basic benchmarks to enable performance regression checks
+
 ## [0.3.3](https://github.com/segfault-merchant/git-stratum/compare/v0.3.2...v0.3.3) - 2026-05-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.4](https://github.com/segfault-merchant/git-stratum/compare/v0.3.3...v0.3.4) - 2026-05-14

### Added

- basic benchmarks to enable performance regression checks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).