### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/segfault-merchant/git-stratum/compare/v0.3.6...v0.3.7) - 2026-05-16
+
+### Added
+
+- define method to return the project path
+
 ## [0.3.6](https://github.com/segfault-merchant/git-stratum/compare/v0.3.5...v0.3.6) - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/segfault-merchant/git-stratum/compare/v0.3.6...v0.3.7) - 2026-05-16

### Added

- define method to return the project path
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).