### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/segfault-merchant/git-stratum/compare/v0.3.8...v0.4.0) - 2026-05-16
+
+### Added
+
+- test mfile function and update test fixture
+- define filename method, resolving the filename according to old and new path
+
 ## [0.3.8](https://github.com/segfault-merchant/git-stratum/compare/v0.3.7...v0.3.8) - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.3.8"
+version = "0.4.0"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.3.8 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `git-stratum` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  ModifiedFile::new_file, previously in file /tmp/.tmpw3VSpl/git-stratum/src/domain/mfile.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/segfault-merchant/git-stratum/compare/v0.3.8...v0.4.0) - 2026-05-16

### Added

- test mfile function and update test fixture
- define filename method, resolving the filename according to old and new path
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).