### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/segfault-merchant/git-stratum/compare/v0.4.4...v0.4.5) - 2026-05-17
+
+### Added
+
+- mv commit unit tests to tests
+
 ## [0.4.4](https://github.com/segfault-merchant/git-stratum/compare/v0.4.3...v0.4.4) - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "chrono",
  "criterion",

--- a/stratum/Cargo.toml
+++ b/stratum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `git-stratum-utils`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `git-stratum`

<blockquote>


## [0.4.5](https://github.com/segfault-merchant/git-stratum/compare/v0.4.4...v0.4.5) - 2026-05-17

### Added

- mv commit unit tests to tests
</blockquote>

## `git-stratum-utils`

<blockquote>

## [0.1.0](https://github.com/segfault-merchant/git-stratum/releases/tag/git-stratum-utils-v0.1.0) - 2026-05-17

### Added

- move common code into utilities crate for simpler reuse in main crate
- define future crates with gitkeep

### Fixed

- update changelog configs for subcrate to not use the main changelog
- update dependencies across the workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).