### PR TITLE
feat: mv commit unit tests to tests

### DIFF
--- a/stratum/src/domain/commit.rs
+++ b/stratum/src/domain/commit.rs
@@ -240,10 +240,7 @@ impl<'repo> Commit<'repo> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        Local, Repository,
-        common::{EXPECTED_ACTOR_EMAIL, EXPECTED_ACTOR_NAME, init_repo},
-    };
+    use crate::{Local, Repository, common::init_repo};
 
     fn commit_fixture<F, R>(f: F) -> R
     where
@@ -255,78 +252,6 @@ mod test {
         let commit = repo.head().expect("Failed to get HEAD");
 
         f(&repo, &commit)
-    }
-
-    #[test]
-    fn test_author() {
-        commit_fixture(|_, commit| {
-            assert_eq!(
-                commit.author().name().unwrap(),
-                EXPECTED_ACTOR_NAME.to_string()
-            );
-            assert_eq!(
-                commit.author().email().unwrap(),
-                EXPECTED_ACTOR_EMAIL.to_string()
-            );
-        });
-    }
-
-    #[test]
-    fn test_co_authors() {
-        commit_fixture(|_, commit| {
-            for co_auth in commit.co_authors() {
-                assert!(co_auth.is_ok());
-            }
-        });
-    }
-
-    #[test]
-    fn test_committer() {
-        commit_fixture(|_, commit| {
-            assert_eq!(
-                commit.committer().name().unwrap(),
-                EXPECTED_ACTOR_NAME.to_string()
-            );
-            assert_eq!(
-                commit.committer().email().unwrap(),
-                EXPECTED_ACTOR_EMAIL.to_string()
-            );
-        });
-    }
-
-    #[test]
-    fn test_parents() {
-        commit_fixture(|_, commit| {
-            assert_eq!(commit.parents().collect::<Vec<String>>().len(), 1);
-        });
-    }
-
-    #[test]
-    fn test_is_merge() {
-        commit_fixture(|_, commit| {
-            assert!(!commit.is_merge());
-        });
-    }
-
-    #[test]
-    fn test_insertions() {
-        commit_fixture(|_, commit| {
-            assert_eq!(commit.insertions().unwrap(), 1);
-        });
-    }
-
-    #[test]
-    fn test_deletions() {
-        commit_fixture(|_, commit| {
-            assert_eq!(commit.deletions().unwrap(), 0);
-        });
-    }
-
-    #[test]
-    fn test_lines() {
-        commit_fixture(|_, commit| {
-            assert_eq!(commit.lines().unwrap(), 1);
-        });
     }
 
     #[test]

--- a/stratum/tests/commit.rs
+++ b/stratum/tests/commit.rs
@@ -1,7 +1,9 @@
 mod common;
+
 use common::repo_fixture;
 
 const SMALL_REPO_COMMIT: &str = "1f99848edadfffa903b8ba1286a935f1b92b2845";
+const SMALL_REPO_COMMIT_PARENT: &str = "09f6182cef737db02a085e1d018963c7a29bde5a";
 
 #[test]
 /// Should capture all local branches, no remote
@@ -114,4 +116,93 @@ fn test_commit_sha() {
 
         assert_eq!(commit.hash(), SMALL_REPO_COMMIT.to_string());
     })
+}
+
+#[test]
+fn test_insertions() {
+    repo_fixture("small_repo", |r| {
+        let commit = r.single(SMALL_REPO_COMMIT).unwrap();
+        assert_eq!(commit.insertions().unwrap(), 16);
+    });
+}
+
+#[test]
+fn test_deletions() {
+    repo_fixture("small_repo", |r| {
+        let commit = r.single(SMALL_REPO_COMMIT).unwrap();
+        assert_eq!(commit.deletions().unwrap(), 0);
+    });
+}
+
+#[test]
+fn test_lines() {
+    repo_fixture("small_repo", |r| {
+        let commit = r.single(SMALL_REPO_COMMIT).unwrap();
+        assert_eq!(commit.lines().unwrap(), 16);
+    });
+}
+
+#[test]
+fn test_parents() {
+    repo_fixture("small_repo", |r| {
+        let commit = r.single(SMALL_REPO_COMMIT).unwrap();
+        let parent = commit.parents().next().unwrap();
+
+        assert_eq!(parent, SMALL_REPO_COMMIT_PARENT);
+    });
+}
+
+#[test]
+fn test_no_merge() {
+    repo_fixture("small_repo", |r| {
+        let commit = r.single(SMALL_REPO_COMMIT).unwrap();
+        assert!(!commit.is_merge());
+    });
+}
+
+#[test]
+fn test_is_merge() {
+    repo_fixture("branches_merged", |r| {
+        let commit = r
+            .single("29e929fbc5dc6a2e9c620069b24e2a143af4285f")
+            .unwrap();
+        assert!(commit.is_merge());
+    });
+}
+
+#[test]
+fn test_author() {
+    repo_fixture("empty_file_changes", |r| {
+        let commit = r
+            .single("a28978951e78b466665026534573bd4e28fd2492")
+            .unwrap();
+        let author = commit.author();
+
+        assert_eq!(author.name(), Some("Jordan"));
+    });
+}
+
+#[test]
+fn test_committer() {
+    repo_fixture("empty_file_changes", |r| {
+        let commit = r
+            .single("a28978951e78b466665026534573bd4e28fd2492")
+            .unwrap();
+        let committer = commit.committer();
+
+        assert_eq!(committer.name(), Some("Jordan"));
+    });
+}
+
+#[test]
+fn test_co_authors() {
+    repo_fixture("multiple_authors", |r| {
+        let commit = r
+            .single("a455e6c8ba6960aa8b89bd0fd5f9abefcd10bcd6")
+            .unwrap();
+        let author = commit.co_authors().next().unwrap().unwrap();
+
+        assert_eq!(author.name(), Some("Somebody"));
+        assert_eq!(author.email(), Some("some@body.org"));
+    });
 }


### PR DESCRIPTION
This is in an effort to reduce the need for extensively modifying the "mock data" and make better use of the already generated "real" data.