### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - define method to return parents as objects
 - mv commit unit tests to tests
 
+### Other
+
+- release
+
+## [0.4.5](https://github.com/segfault-merchant/git-stratum/compare/v0.4.4...v0.4.5) - 2026-05-17
+
+### Added
+
+- define method to return parents as objects
+- mv commit unit tests to tests
+
 ## [0.4.4](https://github.com/segfault-merchant/git-stratum/compare/v0.4.3...v0.4.4) - 2026-05-17
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.4.4 -> 0.4.5
* `git-stratum-utils`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `git-stratum`

<blockquote>


## [0.4.5](https://github.com/segfault-merchant/git-stratum/compare/v0.4.4...v0.4.5) - 2026-05-17

### Added

- define method to return parents as objects
- mv commit unit tests to tests

### Other

- release
</blockquote>

## `git-stratum-utils`

<blockquote>

## [0.1.0](https://github.com/segfault-merchant/git-stratum/releases/tag/git-stratum-utils-v0.1.0) - 2026-05-17

### Added

- move common code into utilities crate for simpler reuse in main crate
- define future crates with gitkeep

### Fixed

- update changelog configs for subcrate to not use the main changelog
- update dependencies across the workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).