### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/segfault-merchant/git-stratum/compare/v0.4.5...v0.5.0) - 2026-05-19
+
+### Added
+
+- cache diff patches
+- cache diff and stat results
+
+### Other
+
+- rm completed TODO
+- rm todo from ammended function
+- add lru crate for cache management
+
 ## [0.4.5](https://github.com/segfault-merchant/git-stratum/compare/v0.4.4...v0.4.5) - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "git-stratum"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/stratum/Cargo.toml
+++ b/stratum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-stratum"
-version = "0.4.5"
+version = "0.5.0"
 authors = ["Jordan Morris <165378667+jordan-314@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.4.5 -> 0.5.0 (⚠ API breaking changes)
* `git-stratum-utils`: 0.1.0

### ⚠ `git-stratum` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:PoisonedCache in /tmp/.tmpn2n3ec/git-stratum/stratum/src/lib.rs:52
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `git-stratum`

<blockquote>


## [0.5.0](https://github.com/segfault-merchant/git-stratum/compare/v0.4.5...v0.5.0) - 2026-05-19

### Added

- cache diff patches
- cache diff and stat results

### Other

- rm completed TODO
- rm todo from ammended function
- add lru crate for cache management
</blockquote>

## `git-stratum-utils`

<blockquote>

## [0.1.0](https://github.com/segfault-merchant/git-stratum/releases/tag/git-stratum-utils-v0.1.0) - 2026-05-17

### Added

- move common code into utilities crate for simpler reuse in main crate
- define future crates with gitkeep

### Fixed

- update changelog configs for subcrate to not use the main changelog
- update dependencies across the workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).