### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- release
+- rm completed TODO
+- rm todo from ammended function
+- add lru crate for cache management
+
+## [0.5.0](https://github.com/segfault-merchant/git-stratum/compare/v0.4.5...v0.5.0) - 2026-05-19
+
+### Added
+
+- cache diff patches
+- cache diff and stat results
+
+### Other
+
 - rm completed TODO
 - rm todo from ammended function
 - add lru crate for cache management


### PR DESCRIPTION



## 🤖 New release

* `git-stratum`: 0.4.5 -> 0.5.0
* `git-stratum-utils`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `git-stratum`

<blockquote>


## [0.5.0](https://github.com/segfault-merchant/git-stratum/compare/v0.4.5...v0.5.0) - 2026-05-19

### Added

- cache diff patches
- cache diff and stat results

### Other

- release
- rm completed TODO
- rm todo from ammended function
- add lru crate for cache management
</blockquote>

## `git-stratum-utils`

<blockquote>

## [0.1.0](https://github.com/segfault-merchant/git-stratum/releases/tag/git-stratum-utils-v0.1.0) - 2026-05-17

### Added

- move common code into utilities crate for simpler reuse in main crate
- define future crates with gitkeep

### Fixed

- update changelog configs for subcrate to not use the main changelog
- update dependencies across the workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).